### PR TITLE
Feat browse

### DIFF
--- a/AbstractNode.php
+++ b/AbstractNode.php
@@ -151,7 +151,12 @@
             }
         }
         
-        
+        /**
+         * Method to add several children node from a unidimensionnal array.
+         *   Raise a notice if a multidimensionnal array is used.
+         * @access public
+         * @param array $children 
+         */         
         public function addChildren(array $children)
         {    
             foreach ($children as $key => $value)
@@ -315,16 +320,31 @@
         /**
          * Browse into a tree node. 
          * @param String $path The path to browse
-         * @param String $delimiter The delimiter for keys in path string
+         * @param String $delimiter The delimiter for keys in path string (default. "/")
+         * @param boolean $strict If true, stop browsing on first error. (default. true)
+         * @return AbstractNode|null
          */ 
-        public function browse($path, $delimiter = '/')
+        public function browse($path, $delimiter = '/', $strict = true)
         {
             $currentNode = $this;
             
             foreach (explode($delimiter, $path) as $key)
-            {
-                if (false === ($currentNode = $currentNode->childByKey($key)))
-                    break;
+            {   
+                if (!empty($key))
+                {
+                    if ($currentNode->childByKey($key) === false)
+                    {
+                        if ($strict)
+                        {
+                            trigger_error("Error encountered while parsing path : $path at $key. Aborting.", E_USER_WARNING);
+                            return false;
+                        }
+                        else
+                            break;
+                    }
+                    else
+                        $currentNode = $currentNode->childByKey($key);    
+                }
             }
             
             return $currentNode;

--- a/AbstractNode.php
+++ b/AbstractNode.php
@@ -311,7 +311,24 @@
             
             return $result;
         }
-   
+        
+        /**
+         * Browse into a tree node. 
+         * @param String $path The path to browse
+         * @param String $delimiter The delimiter for keys in path string
+         */ 
+        public function browse($path, $delimiter = '/')
+        {
+            $currentNode = $this;
+            
+            foreach (explode($delimiter, $path) as $key)
+            {
+                if (false === ($currentNode = $currentNode->childByKey($key)))
+                    break;
+            }
+            
+            return $currentNode;
+        }
     }
 
 ?>


### PR DESCRIPTION
# browse() method
## Introduction

_browse()_ method allows you to navigate more easily in a tree node.
## Prototype

``` php
false|AbstractNode browse ( string $path [, string $delimiter = '/' [, boolean $strict = true ] ] )
```
## Usage

**i.e :** To get the node with the key "chapter1", child of the node "1.a", itself child of node "1" from a tree node root.

``` php
$chap1 = $tree->childByKey('1')->childByKey('1.a')->childByKey('chapter1');
```

now can be write :

``` php
$chap1 = $tree->browse("1/1.a/chapter1");
```
## Parameters
- path, String 
- delimiter, String 
- Strict, boolean : 
  - true : The method triggers a warning and returns false on first non-existing key, even if the wrong key is at the end of the path.
  - false : The method stops on first error, but return the last correct node found with the previous key of the path.

If the first key of the path is wrong, it returns the node itself.
For example : 

``` php
$node->browse("ok/correct/wrong")
```

return exactly the same that 

``` php
$node->browse("ok/correct") (wrong is ignored)
```
